### PR TITLE
Run full test suite

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -63,4 +63,4 @@ jobs:
       run: |
         source ./venv/bin/activate
         export PATH=$PATH:$HOME/.local/bin
-        pytest raiden_common/tests/unit -n 4 -x
+        pytest raiden_common/tests -n 4 -x


### PR DESCRIPTION
We started with only the unit tests to get the CI going. But now we are
ready to run all tests. https://github.com/raiden-network/raiden-common/issues/10 is still open, though.