### PR TITLE
Support "nitro" ETH client 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.1.4 (2022-09-22)
+* Add support for nitro ETH client
+
 ## 0.1.3 (2022-07-28)
 * Split off `raiden-common` package from `raiden` package to allow projects to depend on helpful code without pulling in the whole raiden client.

--- a/raiden_common/constants.py
+++ b/raiden_common/constants.py
@@ -140,6 +140,7 @@ class EthClient(Enum):
     GETH = "geth"
     PARITY = "parity"
     ARBITRUM = "arbitrum"
+    NITRO = "nitro"
 
 
 SNAPSHOT_STATE_CHANGES_COUNT = 500

--- a/raiden_common/network/rpc/client.py
+++ b/raiden_common/network/rpc/client.py
@@ -328,8 +328,10 @@ def discover_next_available_nonce(web3: Web3, eth_node: EthClient, address: Addr
     elif eth_node is EthClient.GETH:
         geth_assert_rpc_interfaces(web3)
         available_nonce = geth_discover_next_available_nonce(web3, address)
-    elif eth_node is EthClient.ARBITRUM:
+    elif eth_node in (EthClient.ARBITRUM, EthClient.NITRO):
         available_nonce = geth_discover_next_available_nonce(web3, address)
+    else:
+        raise Exception(f"discover_next_available_nonce not implemented for {eth_node}")
 
     return available_nonce
 

--- a/raiden_common/utils/ethereum_clients.py
+++ b/raiden_common/utils/ethereum_clients.py
@@ -86,5 +86,8 @@ def is_supported_client(
     elif client_version.startswith("arb-rpc-node"):
         our_version = client_version.split("/")[-1][1:]
         return VersionSupport.SUPPORTED, EthClient.ARBITRUM, our_version
+    elif client_version.startswith("nitro"):
+        our_version = client_version.split("/")[1]
+        return VersionSupport.SUPPORTED, EthClient.NITRO, our_version
 
     return VersionSupport.UNSUPPORTED, None, None


### PR DESCRIPTION
This is used by current Arbitrum networks. Also prepare a new release, so that we can include Arbitrum networks in the explorer.