### PR TITLE
Fix tests in python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
           - "flake8-tuple==0.4.1"
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.982
     hooks:
       - id: mypy
         entry: tools/pre-commit/pre-commit-wrapper.py mypy

--- a/raiden_common/api/rest.py
+++ b/raiden_common/api/rest.py
@@ -367,7 +367,7 @@ class APIServer(Runnable):  # pragma: no unittest
                 response = send_from_directory(self.flask_app.config["WEBUI_PATH"], "index.html")
         return response
 
-    def _run(self) -> None:  # type: ignore
+    def _run(self) -> None:
         try:
             # stop may have been executed before _run was scheduled, in this
             # case wsgiserver will be None

--- a/raiden_common/network/transport/matrix/transport.py
+++ b/raiden_common/network/transport/matrix/transport.py
@@ -313,7 +313,7 @@ class _RetryQueue(Runnable):
                         self.receiver, message_batch, receiver_metadata=address_metadata
                     )
 
-    def _run(self) -> None:  # type: ignore
+    def _run(self) -> None:
         msg = (
             """_RetryQueue started before transport._raiden_service is set. """
             """_RetryQueue should not be started before transport.start() is called"""
@@ -548,7 +548,7 @@ class MatrixTransport(Runnable):
             return
         self._client.set_presence_state(state.value)
 
-    def _run(self) -> None:  # type: ignore
+    def _run(self) -> None:
         """Runnable main method, perform wait on long-running subtasks"""
         # dispatch auth data on first scheduling after start
         assert self._raiden_service is not None, "_raiden_service not set"

--- a/raiden_common/utils/typing.py
+++ b/raiden_common/utils/typing.py
@@ -79,13 +79,13 @@ T_Address = bytes
 AddressHex = HexAddress
 
 T_Balance = int
-Balance = NewType("Balance", T_Balance)
+Balance = NewType("Balance", int)
 
 T_GasPrice = int
-GasPrice = NewType("GasPrice", T_GasPrice)
+GasPrice = NewType("GasPrice", int)
 
 T_BlockGasLimit = int
-BlockGasLimit = NewType("BlockGasLimit", T_BlockGasLimit)
+BlockGasLimit = NewType("BlockGasLimit", int)
 
 T_BlockHash = bytes
 BlockHash = Hash32
@@ -93,106 +93,106 @@ BlockHash = Hash32
 T_BlockNumber = int
 
 T_Timestamp = int
-Timestamp = NewType("Timestamp", T_Timestamp)
+Timestamp = NewType("Timestamp", int)
 
 # A relative number of blocks
 T_BlockTimeout = int
-BlockTimeout = NewType("BlockTimeout", T_BlockTimeout)
+BlockTimeout = NewType("BlockTimeout", int)
 
 T_ChannelState = int
-ChannelState = NewType("ChannelState", T_ChannelState)
+ChannelState = NewType("ChannelState", int)
 
 T_InitiatorAddress = bytes
-InitiatorAddress = NewType("InitiatorAddress", T_InitiatorAddress)
+InitiatorAddress = NewType("InitiatorAddress", bytes)
 
 T_MessageID = int
-MessageID = NewType("MessageID", T_MessageID)
+MessageID = NewType("MessageID", int)
 
 T_Nonce = int
 
 T_NetworkTimeout = float
-NetworkTimeout = NewType("NetworkTimeout", T_NetworkTimeout)
+NetworkTimeout = NewType("NetworkTimeout", float)
 
 T_PaymentID = int
-PaymentID = NewType("PaymentID", T_PaymentID)
+PaymentID = NewType("PaymentID", int)
 
 # PaymentAmount is for amounts of tokens paid end-to-end
 T_PaymentAmount = int
-PaymentAmount = NewType("PaymentAmount", T_PaymentAmount)
+PaymentAmount = NewType("PaymentAmount", int)
 
 T_PublicKey = bytes
-PublicKey = NewType("PublicKey", T_PublicKey)
+PublicKey = NewType("PublicKey", bytes)
 
 T_FeeAmount = int
-FeeAmount = NewType("FeeAmount", T_FeeAmount)
+FeeAmount = NewType("FeeAmount", int)
 
 # A proportional fee, unit is parts-per-million
 # 1_000_000 means 100%, 25_000 is 2.5%
 T_ProportionalFeeAmount = int
-ProportionalFeeAmount = NewType("ProportionalFeeAmount", T_ProportionalFeeAmount)
+ProportionalFeeAmount = NewType("ProportionalFeeAmount", int)
 
 T_LockedAmount = int
-LockedAmount = NewType("LockedAmount", T_LockedAmount)
+LockedAmount = NewType("LockedAmount", int)
 
 T_PaymentWithFeeAmount = int
-PaymentWithFeeAmount = NewType("PaymentWithFeeAmount", T_FeeAmount)
+PaymentWithFeeAmount = NewType("PaymentWithFeeAmount", int)
 
 T_TokenNetworkRegistryAddress = bytes
-TokenNetworkRegistryAddress = NewType("TokenNetworkRegistryAddress", T_TokenNetworkRegistryAddress)
+TokenNetworkRegistryAddress = NewType("TokenNetworkRegistryAddress", bytes)
 
 T_RaidenProtocolVersion = int
-RaidenProtocolVersion = NewType("RaidenProtocolVersion", T_RaidenProtocolVersion)
+RaidenProtocolVersion = NewType("RaidenProtocolVersion", int)
 
 T_RaidenDBVersion = int
-RaidenDBVersion = NewType("RaidenDBVersion", T_RaidenDBVersion)
+RaidenDBVersion = NewType("RaidenDBVersion", int)
 
 T_TargetAddress = bytes
-TargetAddress = NewType("TargetAddress", T_TargetAddress)
+TargetAddress = NewType("TargetAddress", bytes)
 
 T_TokenAddress = bytes
-TokenAddress = NewType("TokenAddress", T_TokenAddress)
+TokenAddress = NewType("TokenAddress", bytes)
 
 T_UserDepositAddress = bytes
-UserDepositAddress = NewType("UserDepositAddress", T_UserDepositAddress)
+UserDepositAddress = NewType("UserDepositAddress", bytes)
 
 T_MonitoringServiceAddress = bytes
-MonitoringServiceAddress = NewType("MonitoringServiceAddress", T_MonitoringServiceAddress)
+MonitoringServiceAddress = NewType("MonitoringServiceAddress", bytes)
 
 T_ServiceRegistryAddress = bytes
-ServiceRegistryAddress = NewType("ServiceRegistryAddress", T_ServiceRegistryAddress)
+ServiceRegistryAddress = NewType("ServiceRegistryAddress", bytes)
 
 T_OneToNAddress = bytes
-OneToNAddress = NewType("OneToNAddress", T_OneToNAddress)
+OneToNAddress = NewType("OneToNAddress", bytes)
 
 T_TokenNetworkAddress = bytes
-TokenNetworkAddress = NewType("TokenNetworkAddress", T_TokenNetworkAddress)
+TokenNetworkAddress = NewType("TokenNetworkAddress", bytes)
 
 T_TransferID = bytes
-TransferID = NewType("TransferID", T_TransferID)
+TransferID = NewType("TransferID", bytes)
 
 T_Secret = bytes
-Secret = NewType("Secret", T_Secret)
+Secret = NewType("Secret", bytes)
 
 T_EncryptedSecret = bytes
-EncryptedSecret = NewType("EncryptedSecret", T_EncryptedSecret)
+EncryptedSecret = NewType("EncryptedSecret", bytes)
 
 T_SecretHash = bytes
-SecretHash = NewType("SecretHash", T_SecretHash)
+SecretHash = NewType("SecretHash", bytes)
 
 T_SecretRegistryAddress = bytes
-SecretRegistryAddress = NewType("SecretRegistryAddress", T_SecretRegistryAddress)
+SecretRegistryAddress = NewType("SecretRegistryAddress", bytes)
 
 T_TransactionHash = bytes
-TransactionHash = NewType("TransactionHash", T_TransactionHash)
+TransactionHash = NewType("TransactionHash", bytes)
 
 T_EncodedData = bytes
-EncodedData = NewType("EncodedData", T_EncodedData)
+EncodedData = NewType("EncodedData", bytes)
 
 T_WithdrawAmount = int
-WithdrawAmount = NewType("WithdrawAmount", T_WithdrawAmount)
+WithdrawAmount = NewType("WithdrawAmount", int)
 
 T_MetadataHash = bytes
-MetadataHash = NewType("MetadataHash", T_MetadataHash)
+MetadataHash = NewType("MetadataHash", bytes)
 
 NodeNetworkStateMap = Dict[Address, "NetworkState"]
 
@@ -208,10 +208,10 @@ LockedTransferType = Union["LockedTransferUnsignedState", "LockedTransferSignedS
 DatabasePath = Union[Path, Literal[":memory:"]]
 
 T_PeerCapabilities = Dict[str, Union[str, bool]]
-PeerCapabilities = NewType("PeerCapabilities", T_PeerCapabilities)
+PeerCapabilities = NewType("PeerCapabilities", Dict)
 
 T_UserID = str
-UserID = NewType("UserID", T_UserID)
+UserID = NewType("UserID", str)
 
 AddressMetadata = Dict[str, Union[UserID, str]]
 

--- a/requirements/requirements-ci.txt
+++ b/requirements/requirements-ci.txt
@@ -338,13 +338,13 @@ markupsafe==2.0.1
     # via
     #   -r requirements-dev.txt
     #   jinja2
-marshmallow==3.15.0
+marshmallow==3.18.0
     # via
     #   -r requirements-dev.txt
     #   marshmallow-dataclass
     #   marshmallow-enum
     #   marshmallow-polyfield
-marshmallow-dataclass[union]==8.0.0
+marshmallow-dataclass[union]==8.5.9
     # via -r requirements-dev.txt
 marshmallow-enum==1.5.1
     # via -r requirements-dev.txt
@@ -378,7 +378,7 @@ multidict==5.1.0
     #   -r requirements-dev.txt
     #   aiohttp
     #   yarl
-mypy==0.950
+mypy==0.982
     # via -r requirements-dev.txt
 mypy-extensions==0.4.3
     # via
@@ -733,7 +733,8 @@ typing-extensions==4.3.0
     #   matrix-synapse
     #   mypy
     #   signedjson
-typing-inspect==0.4.0
+    #   typing-inspect
+typing-inspect==0.8.0
     # via
     #   -r requirements-dev.txt
     #   marshmallow-dataclass

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -295,13 +295,13 @@ markupsafe==2.0.1
     # via
     #   -r requirements.txt
     #   jinja2
-marshmallow==3.15.0
+marshmallow==3.18.0
     # via
     #   -r requirements.txt
     #   marshmallow-dataclass
     #   marshmallow-enum
     #   marshmallow-polyfield
-marshmallow-dataclass[union]==8.0.0
+marshmallow-dataclass[union]==8.5.9
     # via -r requirements.txt
 marshmallow-enum==1.5.1
     # via -r requirements.txt
@@ -330,7 +330,7 @@ multidict==5.1.0
     #   -r requirements.txt
     #   aiohttp
     #   yarl
-mypy==0.950
+mypy==0.982
     # via -r requirements-dev.in
 mypy-extensions==0.4.3
     # via
@@ -617,7 +617,8 @@ typing-extensions==4.3.0
     #   matrix-synapse
     #   mypy
     #   signedjson
-typing-inspect==0.4.0
+    #   typing-inspect
+typing-inspect==0.8.0
     # via
     #   -r requirements.txt
     #   marshmallow-dataclass

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -138,13 +138,13 @@ lru-dict==1.1.6
     # via web3
 markupsafe==2.0.1
     # via jinja2
-marshmallow==3.15.0
+marshmallow==3.18.0
     # via
     #   -r requirements.in
     #   marshmallow-dataclass
     #   marshmallow-enum
     #   marshmallow-polyfield
-marshmallow-dataclass[union]==8.0.0
+marshmallow-dataclass[union]==8.5.9
     # via -r requirements.in
 marshmallow-enum==1.5.1
     # via -r requirements.in
@@ -244,7 +244,8 @@ typing-extensions==4.3.0
     # via
     #   -r requirements.in
     #   aiohttp
-typing-inspect==0.4.0
+    #   typing-inspect
+typing-inspect==0.8.0
     # via marshmallow-dataclass
 ulid-py==1.1.0
     # via -r requirements.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ warn_unused_ignores = True
 warn_unreachable = True
 warn_redundant_casts = True
 strict_equality = True
+plugins = marshmallow_dataclass.mypy
 
 # These parts of raiden are not fully typed, yet
 [mypy-raiden_common.utils.profiling.*]


### PR DESCRIPTION
## Use `marshmallow_dataclass.NewType` and upgrade `mypy`

Fixes: compatibility with python `>= 3.10`; without these changes there are `~60` spurious test failures.

Due to ["Changes in version 3.10"](https://docs.python.org/3/library/typing.html#newtype)
> NewType is now a class rather than a function. There is some additional runtime cost when calling NewType over a regular function. However, this cost will be reduced in 3.11.0.

we need to use `marshmallow_dataclass`'s `NewType` implementation ([see "Custom NewType declarations" here](https://pypi.org/project/marshmallow-dataclass/)), which brings the other changes as a necessity.
