### PR TITLE
Add http_retry_with_backoff_middleware

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,14 +200,14 @@ all patch releases for the corresponding major release.
 
 To run the tests use pytest
 
-    pytest raiden
+    pytest raiden_common
 
 Tests are split in unit tests, fuzz tests (which are currently grouped under
 unit tests) and integration tests. The first are faster to execute while
 the latter test the whole system but are slower to run. To choose which type of
 tests to run, just use the appropriate directory.
 
-    pytest raiden/tests/<integration|unit>
+    pytest raiden_common/tests/<integration|unit>
 
 For a detailed explanation of the different types of tests, see the
 [test suite section](#test-suite) below.
@@ -640,7 +640,7 @@ Subsequently you can render them to an `.svg` by doing `flamegraph.pl  /path/to/
 
 A test run can be profiled by providing an extra argument to pytest `--profiler=flamegraph-trace`. For example:
 
-`pytest --profiler=flamegraph-trace -xs raiden/tests/integration/api/test_restapi.py::test_api_payments`
+`pytest --profiler=flamegraph-trace -xs raiden_common/tests/integration/api/test_restapi.py::test_api_payments`
 
 Will generate stack data under `/tmp/datetime_stack.data`. Just as before you can render it into a flamegreaph by doing `flamegraph.pl /tmp/datetime_stack.data`.
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ test:
 	pytest -n auto -v raiden_common/tests
 
 coverage:
-	coverage run --source raiden -m pytest -v raiden/tests
+	coverage run --source raiden -m pytest -v raiden_common/tests
 	coverage report -m
 	coverage html
 

--- a/conftest.py
+++ b/conftest.py
@@ -8,13 +8,14 @@ monkey.patch_all(subprocess=False, thread=False)
 # isort: split
 
 import pkgutil
+
 import pytest
 
-# Register pytest assert rewriting on all submodules of `raiden/tests/utils`.
+# Register pytest assert rewriting on all submodules of `raiden_common/tests/utils`.
 # This is necessary due to our split fixture setup since pytest doesn't detect these
 # imports automatically.
-for module_info in pkgutil.iter_modules(["raiden/tests/utils"]):
-    pytest.register_assert_rewrite(f"raiden.tests.utils.{module_info.name}")
+for module_info in pkgutil.iter_modules(["raiden_common/tests/utils"]):
+    pytest.register_assert_rewrite(f"raiden_common.tests.utils.{module_info.name}")
 
 # isort:split
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ exclude = '''
 
 [tool.pytest.ini_options]
 testpaths = [
-    "raiden/tests",
+    "raiden_common/tests",
 ]
 addopts = "--no-success-flaky-report"
 timeout_limit_for_setup_and_call = 240

--- a/raiden_common/blockchain/middleware.py
+++ b/raiden_common/blockchain/middleware.py
@@ -1,0 +1,46 @@
+from typing import Any, Callable, Dict, Tuple
+
+import gevent
+import requests.exceptions
+from web3 import Web3
+from web3.middleware.exception_retry_request import check_if_retry_on_failure
+from web3.types import RPCEndpoint
+
+
+def http_retry_with_backoff_middleware(
+    make_request: Callable,
+    web3: Web3,  # pylint: disable=unused-argument
+    errors: Tuple = (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.HTTPError,
+        requests.exceptions.Timeout,
+        requests.exceptions.TooManyRedirects,
+    ),
+    retries: int = 10,
+    first_backoff: float = 0.2,
+    backoff_factor: float = 2,
+) -> Callable:
+    """Retry requests with exponential backoff
+
+    Creates middleware that retries failed HTTP requests and exponentially
+    increases the backoff between retries. Meant to replace the default
+    middleware `http_retry_request_middleware` for HTTPProvider.
+    """
+
+    def middleware(method: RPCEndpoint, params: Dict) -> Any:
+        backoff = first_backoff
+        if check_if_retry_on_failure(method):
+            for i in range(retries):
+                try:
+                    return make_request(method, params)
+                except errors:
+                    if i < retries - 1:
+                        gevent.sleep(backoff)
+                        backoff *= backoff_factor
+                        continue
+
+                    raise
+        else:
+            return make_request(method, params)
+
+    return middleware

--- a/raiden_common/tests/unit/test_middleware.py
+++ b/raiden_common/tests/unit/test_middleware.py
@@ -1,0 +1,52 @@
+from time import time
+from unittest.mock import patch
+
+import pytest
+import requests.exceptions
+from web3 import Web3
+from web3.providers import HTTPProvider
+
+from raiden_common.blockchain.middleware import http_retry_with_backoff_middleware
+
+
+@patch("web3.providers.rpc.make_post_request")
+def test_retries(make_post_request_mock):
+
+    # use short backoff times to make the test run quickly
+    def quick_retry_middleware(make_request, web3):
+        return http_retry_with_backoff_middleware(
+            make_request, web3, retries=5, first_backoff=0.01
+        )
+
+    provider = HTTPProvider()
+    provider.middlewares.replace(  # pylint: disable=no-member
+        "http_retry_request", quick_retry_middleware
+    )
+    web3 = Web3(provider)
+
+    # log the time since start each time the mock is called
+    start_time = time()
+    retry_times = []
+
+    def side_effect(*_args, **_kwargs):
+        retry_times.append(time() - start_time)
+        raise requests.exceptions.ConnectionError
+
+    make_post_request_mock.side_effect = side_effect
+
+    # the call must fail after the number of retries is exceeded
+    with pytest.raises(requests.exceptions.ConnectionError):
+        web3.eth.block_number  # pylint: disable=pointless-statement
+
+    # check timings
+    assert make_post_request_mock.call_count == 5
+    expected_times = [0, 0.01, 0.01 + 0.02, 0.01 + 0.02 + 0.04, 0.01 + 0.02 + 0.04 + 0.08]
+    assert retry_times == pytest.approx(expected_times, abs=0.006, rel=0.3)
+
+    # try again to make sure that each request starts with a clean backoff
+    start_time = time()
+    retry_times = []
+    with pytest.raises(requests.exceptions.ConnectionError):
+        web3.eth.block_number  # pylint: disable=pointless-statement
+
+    assert retry_times == pytest.approx(expected_times, abs=0.006, rel=0.3)


### PR DESCRIPTION
It is already used in the PFS and will be used in the explorer, so it
makes sense to pull it into raiden_common.